### PR TITLE
fix: Update overlay to use stdenv.hostPlatform.system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
   outputs = { self, nixpkgs, crane, flake-utils }:
     {
       overlays.default = final: prev: {
-        inherit (self.packages.${prev.system}) fsh;
+        inherit (self.packages.${prev.stdenv.hostPlatform.system}) fsh;
       };
       homeModules.fsh = import ./home.nix;
     } // flake-utils.lib.eachDefaultSystem (system:


### PR DESCRIPTION
`pkgs.system` is deprecated, use `pkgs.stdenv.hostPlatform.system` instead to fix following warning:

`evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`

https://discourse.nixos.org/t/how-to-fix-evaluation-warning-system-has-been-renamed-to-replaced-by-stdenv-hostplatform-system/72120